### PR TITLE
export typescript StrictTextAreaProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ export {
   StrictResponsiveProps,
 } from './dist/commonjs/addons/Responsive'
 export { default as Select, SelectProps } from './dist/commonjs/addons/Select'
-export { default as TextArea, TextAreaProps } from './dist/commonjs/addons/TextArea'
+export { default as TextArea, TextAreaProps, StrictTextAreaProps } from './dist/commonjs/addons/TextArea'
 export {
   default as TransitionablePortal,
   TransitionablePortalProps,


### PR DESCRIPTION
exporting StrictTextAreaProps as it was not exported.